### PR TITLE
Metadata: user id of last change can be null

### DIFF
--- a/src/UseCase/Metadata.php
+++ b/src/UseCase/Metadata.php
@@ -31,7 +31,7 @@ final class Metadata
      * @Serializer\SerializedName("UserLastChangeId")
      * @Serializer\Type("int")
      */
-    private int $userLastChangedId;
+    private ?int $userLastChangedId;
 
     public function getDateCreated(): DateTimeInterface
     {
@@ -48,7 +48,7 @@ final class Metadata
         return $this->userCreatedId;
     }
 
-    public function getUserLastChangedId(): int
+    public function getUserLastChangedId(): ?int
     {
         return $this->userLastChangedId;
     }


### PR DESCRIPTION
Even though not stated in docs, user last change id returns null until the entity is changed for the first time.

I've come across this in create contact or proforma (not sure which one it was), but I think it will be the same for metadata in all endpoints using it. But **not tested**.